### PR TITLE
Enhance ConfigInterface with Retry Logic and Cache Management

### DIFF
--- a/backend/helpers/cacheManager.js
+++ b/backend/helpers/cacheManager.js
@@ -1,0 +1,90 @@
+const NodeCache = require('node-cache');
+
+class CacheManager {
+    constructor(options = {}) {
+        this.cache = new NodeCache({
+            stdTTL: options.ttl || 300, // Default TTL: 5 minutes
+            checkperiod: options.checkperiod || 60, // Cleanup every 1 minute
+            maxKeys: options.maxKeys || -1, // No limit by default
+            useClones: false
+        });
+
+        this.cache.on('expired', (key, value) => {
+            if (this.onExpired) {
+                this.onExpired(key, value);
+            }
+        });
+
+        this.cache.on('error', (err) => {
+            if (this.onError) {
+                this.onError(err);
+            }
+        });
+    }
+
+    get(key, logger) {
+        try {
+            const value = this.cache.get(key);
+            if (value === undefined) {
+                logger.debug(`Cache miss for key: ${key}`);
+                return null;
+            }
+            logger.debug(`Cache hit for key: ${key}`);
+            return value;
+        } catch (error) {
+            logger.error(`Error getting cache key: ${key}`, error);
+            return null;
+        }
+    }
+
+    set(key, value, ttl = undefined, logger) {
+        try {
+            const success = this.cache.set(key, value, ttl);
+            if (!success) {
+                logger.warn(`Failed to set cache key: ${key}`);
+                return false;
+            }
+            logger.debug(`Successfully set cache key: ${key}`);
+            return true;
+        } catch (error) {
+            logger.error(`Error setting cache key: ${key}`, error);
+            return false;
+        }
+    }
+
+    del(key, logger) {
+        try {
+            const count = this.cache.del(key);
+            logger.debug(`Deleted ${count} keys from cache`);
+            return count > 0;
+        } catch (error) {
+            logger.error(`Error deleting cache key: ${key}`, error);
+            return false;
+        }
+    }
+
+    flush(logger) {
+        try {
+            this.cache.flushAll();
+            logger.info('Cache flushed successfully');
+            return true;
+        } catch (error) {
+            logger.error('Error flushing cache', error);
+            return false;
+        }
+    }
+
+    getStats() {
+        return this.cache.getStats();
+    }
+
+    setOnExpired(callback) {
+        this.onExpired = callback;
+    }
+
+    setOnError(callback) {
+        this.onError = callback;
+    }
+}
+
+module.exports = CacheManager;

--- a/backend/helpers/configInterface.js
+++ b/backend/helpers/configInterface.js
@@ -1,27 +1,98 @@
 const axios = require("axios");
+const CacheManager = require("./cacheManager");
 
 class ConfigInterface {
-  getInterfaceMappingConfig(path, logger) {
-    return new Promise((resolve, reject) => {
-      const config = global.myCache.get(path);
-      if (config) {
-        logger.info("InterfaceMappingConfig cached", path);
-        resolve(config);
-      } else {
-        axios
-        .get(process.env.configServerUrl + path)
-        .then((response) => {
-          logger.info("InterfaceMappingConfig retrieved", path);
-          global.myCache.set(path, response.data);
-          resolve(response.data);
-        })
-        .catch((error) => {
-          logger.error("InterfaceMappingConfig error", error);
-          reject(error);
+    constructor() {
+        this.cacheManager = new CacheManager({
+            ttl: process.env.CONFIG_CACHE_TTL || 300, // 5 minutes default
+            maxKeys: process.env.CONFIG_CACHE_MAX_KEYS || 1000,
+            checkperiod: 60
         });
-      }
-    });
-  }
+
+        this.retryConfig = {
+            maxRetries: process.env.CONFIG_MAX_RETRIES || 3,
+            retryDelay: process.env.CONFIG_RETRY_DELAY || 1000,
+        };
+
+        this.cacheManager.setOnExpired((key, value) => {
+            this.refreshConfig(key).catch(() => {});
+        });
+    }
+
+    async getInterfaceMappingConfig(path, logger) {
+        try {
+            // Try to get from cache first
+            const cachedConfig = this.cacheManager.get(path, logger);
+            if (cachedConfig) {
+                return cachedConfig;
+            }
+
+            // If not in cache, fetch from server
+            return await this.fetchConfigWithRetry(path, logger);
+        } catch (error) {
+            logger.error("Failed to get interface mapping config", {
+                path,
+                error: error.message,
+                stack: error.stack
+            });
+            throw error;
+        }
+    }
+
+    async fetchConfigWithRetry(path, logger, attempt = 1) {
+        try {
+            const response = await axios.get(process.env.configServerUrl + path);
+            logger.info("InterfaceMappingConfig retrieved", { path });
+            
+            // Cache the successful response
+            const cacheSuccess = this.cacheManager.set(path, response.data, undefined, logger);
+            if (!cacheSuccess) {
+                logger.warn("Failed to cache config", { path });
+            }
+
+            return response.data;
+        } catch (error) {
+            if (attempt < this.retryConfig.maxRetries) {
+                logger.warn("Retrying config fetch", {
+                    path,
+                    attempt,
+                    maxRetries: this.retryConfig.maxRetries
+                });
+
+                await new Promise(resolve => 
+                    setTimeout(resolve, this.retryConfig.retryDelay * attempt)
+                );
+
+                return this.fetchConfigWithRetry(path, logger, attempt + 1);
+            }
+
+            throw error;
+        }
+    }
+
+    async refreshConfig(path) {
+        const logger = global.logger || console;
+        try {
+            await this.fetchConfigWithRetry(path, logger);
+        } catch (error) {
+            logger.error("Failed to refresh config", {
+                path,
+                error: error.message
+            });
+        }
+    }
+
+    getCacheStats() {
+        return this.cacheManager.getStats();
+    }
+
+    invalidateCache(path, logger) {
+        return this.cacheManager.del(path, logger);
+    }
+
+    flushCache(logger) {
+        return this.cacheManager.flush(logger);
+    }
 }
 
 module.exports = new ConfigInterface();


### PR DESCRIPTION
### What changes were made
This pull request introduces a new `ConfigInterface` class in `configInterface.js` that integrates with a `CacheManager` class from `cacheManager.js`. The `ConfigInterface` class is responsible for fetching configuration data, caching it, and implementing retry logic for failed fetch attempts. The `CacheManager` class handles caching operations, including setting, getting, deleting, and flushing cache entries.

### Why the changes were needed
The changes were necessary to improve the efficiency and reliability of configuration data retrieval in the application. By caching configuration data, we reduce the number of requests to the configuration server, which can improve performance and reduce server load. Additionally, implementing retry logic ensures that transient network issues do not cause immediate failures in fetching configuration data.

### Important implementation details
- **Caching**: The `ConfigInterface` uses `CacheManager` to cache configuration data with a default TTL of 5 minutes. The cache is checked every minute for expired entries.
- **Retry Logic**: The `fetchConfigWithRetry` method in `ConfigInterface` attempts to fetch configuration data up to a maximum number of retries (default is 3) with an increasing delay between attempts.
- **Environment Variables**: The behavior of caching and retry logic can be customized using environment variables such as `CONFIG_CACHE_TTL`, `CONFIG_CACHE_MAX_KEYS`, `CONFIG_MAX_RETRIES`, and `CONFIG_RETRY_DELAY`.
- **Logging**: Both classes utilize a logger to provide detailed information about cache hits/misses, errors, and retry attempts.

### Testing information
- **Unit Tests**: Ensure that unit tests cover scenarios for cache hits, cache misses, successful fetches, failed fetches with retries, and cache expiration handling.
- **Integration Tests**: Verify that the `ConfigInterface` correctly interacts with the `CacheManager` and handles configuration retrieval as expected in a real-world environment.

Resolves #4